### PR TITLE
Fix MultiSelectCombobox items are removed from ItemsSource if used in…

### DIFF
--- a/Source/CoreLibrary/Controls/MultiSelectCombobox/BasicStructure.cs
+++ b/Source/CoreLibrary/Controls/MultiSelectCombobox/BasicStructure.cs
@@ -51,7 +51,7 @@ namespace BlackPearl.Controls.CoreLibrary
                     richTextBoxElement.RemoveHandler(CommandManager.PreviewExecutedEvent, new ExecutedRoutedEventHandler(SetClipboardTextWithCommandCancelled));
                     richTextBoxElement.DragEnter -= OnDragEnter;
                     richTextBoxElement.Drop -= OnDragDrop;
-                    foreach (var textblock in richTextBoxElement.GetParagraph().Inlines.Select(i => i.GetTextBlock()).Where(i => i != null))
+                    foreach (var textblock in richTextBoxElement.GetParagraph()?.Inlines?.Select(i => i.GetTextBlock())?.Where(i => i != null))
                     {
                         textblock.Unloaded -= Tb_Unloaded;
                     }

--- a/Source/CoreLibrary/Controls/MultiSelectCombobox/BasicStructure.cs
+++ b/Source/CoreLibrary/Controls/MultiSelectCombobox/BasicStructure.cs
@@ -51,6 +51,10 @@ namespace BlackPearl.Controls.CoreLibrary
                     richTextBoxElement.RemoveHandler(CommandManager.PreviewExecutedEvent, new ExecutedRoutedEventHandler(SetClipboardTextWithCommandCancelled));
                     richTextBoxElement.DragEnter -= OnDragEnter;
                     richTextBoxElement.Drop -= OnDragDrop;
+                    foreach (var textblock in richTextBoxElement.GetParagraph().Inlines.Select(i => i.GetTextBlock()).Where(i => i != null))
+                    {
+                        textblock.Unloaded -= Tb_Unloaded;
+                    }
                 }
 
                 richTextBoxElement = value;
@@ -177,7 +181,7 @@ namespace BlackPearl.Controls.CoreLibrary
             get => (ILookUpContract)GetValue(LookUpContractProperty);
             set => SetValue(LookUpContractProperty, value);
         }
-        #endregion  
+        #endregion
 
         #region Property changed callback
         /// <summary>
@@ -196,7 +200,7 @@ namespace BlackPearl.Controls.CoreLibrary
             try
             {
                 //Unsubscribe handlers first
-                if (!multiChoiceControl.UnsubscribeHandler() 
+                if (!multiChoiceControl.UnsubscribeHandler()
                     || multiChoiceControl?.RichTextBoxElement == null)
                 {
                     //Failed to unsubscribe, return


### PR DESCRIPTION
**Issue:**
If the _MultiSelectCombobox_ is used inside of a template (e.g. _ListView.ItemTemplate_) _OnApplyTemplate_ ([BasicStructure.cs#L34](https://github.com/nilayjoshi89/BlackPearl/blob/06e353a7a78c0f549f515fda965c94e6620cd9a8/Source/CoreLibrary/Controls/MultiSelectCombobox/BasicStructure.cs#L34)) is called multiple times. This leads to unloaded textboxes  and removement of the items since the event was not unsubscribed ([Implementation.cs#L721](https://github.com/nilayjoshi89/BlackPearl/blob/06e353a7a78c0f549f515fda965c94e6620cd9a8/Source/CoreLibrary/Controls/MultiSelectCombobox/Implementation.cs#L721)).

**Fix:**
Unsubscribing events to prevent items are removed.